### PR TITLE
Return only the path if creating docs for a single library

### DIFF
--- a/lib/yard/server/doc_server_helper.rb
+++ b/lib/yard/server/doc_server_helper.rb
@@ -67,8 +67,10 @@ module YARD
       # @param [String] path the path prefix for a base path URI
       # @return [String] the base URI for a library with an extra +path+ prefix
       def base_path(path)
+        return path if @single_library
+
         libname = router.request.version_supplied ? @library.to_s : @library.name
-        path + (@single_library ? '' : "/#{libname}")
+        path + "/#{libname}"
       end
 
       # @return [Router] convenience method for accessing the router


### PR DESCRIPTION
We would run into an error where version_supplied is not definited in Yard::Server::DocServerHelper#base_path on router.request. This probably happens because it's refined/overloaded but the request object we get in that method doesn't include that definition. We are using a single library anyways and don't need that check anyways, so let's skip it.